### PR TITLE
Turn main binary into system application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.o
+tsic-temp

--- a/Makefile
+++ b/Makefile
@@ -4,3 +4,5 @@ main: main.cpp tsic.o
 tsic.o: tsic.h tsic.cpp pigpiomgr.h
 	g++ -c tsic.cpp -std=c++0x
 
+clean:
+	rm -rf *.o tsic-temp

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,16 @@
-main: main.cpp tsic.o
+.PHONY: all install clean distclean
+
+all: main.cpp tsic.o
 	g++ -o tsic-temp main.cpp tsic.o -lrt -pthread -lpigpio -std=c++0x
 
 tsic.o: tsic.h tsic.cpp pigpiomgr.h
 	g++ -c tsic.cpp -std=c++0x
 
+install: all
+	cp tsic-temp /usr/local/bin
+
 clean:
 	rm -rf *.o tsic-temp
+
+distclean: clean
+	rm -rf /usr/local/bin/tsic-temp

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 main: main.cpp tsic.o
-	g++ -o main main.cpp tsic.o -lrt -pthread -lpigpio -std=c++0x
+	g++ -o tsic-temp main.cpp tsic.o -lrt -pthread -lpigpio -std=c++0x
 
 tsic.o: tsic.h tsic.cpp pigpiomgr.h
 	g++ -c tsic.cpp -std=c++0x
+

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Basic instructions:
 Compile and run as follows:
 
     make
-    sudo ./main
+    sudo ./tsic-temp
 
 See also:
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ This is a simple C++ class for interfacing to the TSIC-306 Digital Temperature S
 
 Dependencies:
 
-* Requires PIGPIO, which can downloaded from: http://abyz.co.uk/rpi/pigpio
+* Requires PIGPIO
+  * Download from: http://abyz.co.uk/rpi/pigpio
+  * Extract, ``make && make install`` on your system
 * Uses C++11 features
 
 Basic instructions:
@@ -16,7 +18,17 @@ Basic instructions:
 Compile and run as follows:
 
     make
-    sudo ./tsic-temp
+    sudo ./tsic-temp -h         # Get Help
+    sudo ./tsic-temp -g20       # -g defines that the sensor is connected to GPIO20
+    
+ Optional: install system-wide
+ 
+    sudo make install
+    sudo tsic-temp
+    
+ Uninstall:
+ 
+    sudo make distclean
 
 See also:
 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,21 @@
 # tsic-pigpio
 
-This is a simple C++ class for interfacing to the TSIC-306 Digital Temperature Sensor.
+This is a simple C++ class for reading values from TSIC 206 & TSIC 306 digital temperature sensors.
 
-Dependencies:
+**Dependencies**
 
 * Requires PIGPIO
   * Download from: http://abyz.co.uk/rpi/pigpio
   * Extract, ``make && make install`` on your system
 * Uses C++11 features
 
-Basic instructions:
+**Basic instructions**
 
-1. Connect up the TSIC sensor with 3V3, GND and the GPIO pin of your choice
-2. Edit 'main.cpp' to use the correct GPIO pin number in the open() call
-3. Compile and run
-
-Compile and run as follows:
+Connect up the TSIC sensor with 3V3, GND and the GPIO pin of your choice, then compile and run as follows:
 
     make
-    sudo ./tsic-temp -h         # Get Help
-    sudo ./tsic-temp -g20       # -g defines that the sensor is connected to GPIO20
+    sudo ./tsic-temp -h         # get help
+    sudo ./tsic-temp -g20       # -g specifies that the sensor is connected to GPIO20, change accordingly!
     
  Optional: install system-wide
  

--- a/main.cpp
+++ b/main.cpp
@@ -5,19 +5,66 @@ using namespace std;
 int main( int argc, char **argv )
 {
     TSIC tsic;
+    bool bShowFahrenheit(false);
+    char *cvalue = NULL;
+    int iGpio = 20;
+    int c;
 
-    if ( !tsic.open(24) ) {
-        cerr << "open failed\n";
-        return 1;
-    }
+    opterr = 0;
+    while ((c = getopt (argc, argv, "hg::f")) != -1)
+      switch (c)
+        {
+        case 'h':
+          cout << "TSIC 206/306 temperature sensor application" << endl;
+          cout << "  usage:    tsic-temp [arguments]" << endl;
+          cout << "   -f    show temperature in Fahrenheit" << endl;
+          cout << "   -gN   Read data from GPIO pin N (default is 20)" << endl;
+          cout << "   -h    Show this help" << endl;
+          return 0;
+        case 'f':
+          bShowFahrenheit = true;
+          break;
+        case 'g':
+          cvalue = optarg;
+        try   {
+          iGpio = std::stoi(optarg);
+          if (iGpio < 0 || iGpio > 27) {
+            throw;
+          }
+       }
+        catch(...) {
+          cerr << "GPIO option -g requires an argument between 1 and 27" << endl;
+          cerr << "Example: -g24   -- see -h for help." << endl;
+          return 1;
+        }
+          break;
+        case '?':
+          if (optopt == 'g')
+            fprintf (stderr, "Option -%c requires an argument.\n", optopt);
+          else if (isprint (optopt))
+            fprintf (stderr, "Unknown option `-%c'. Check -h for help\n", optopt);
+          else
+            fprintf (stderr,
+                     "Unknown option character `\\x%x'.\n",
+                     optopt);
+          return 1;
+        default:
+          abort ();
+        }
 
-    for (int i=0; i<10; ++i) {
-        double temp = 0.0;
-        if ( !tsic.getDegrees( temp ) )
-            cerr << "getDegrees failed\n";
+      if ( !tsic.open(iGpio) ) {
+          cerr << "open failed\n";
+          return 1;
+      }
 
-        cout << "temp = " << temp << endl;
-    }
+      double temp = 0.0;
+      if ( !tsic.getDegrees( temp ) )
+          cerr << "getDegrees failed\n";
+
+      if  (bShowFahrenheit) {
+              temp = temp*1.8 + 32;
+      }
+      cout << temp << endl;
 
     tsic.close();
 


### PR DESCRIPTION
I extended the `main` app a little. The whole thing now compiles a fully fledged application called `tsic-temp` binary that can be installed system wide via `make install`. Also, it features a `-h` switch for help, a GPIO selection option (`-gNUMBER`) and a `-f` switch to display temperatures in degrees Fahrenheit (for our friends in Belize, Bahamas and ...errr... the United States :+1:) The binary's output has been cleared from syntactic sugar. Thanks for your work @jam3sward!
